### PR TITLE
fix: always use ~/.config/opencode base configuration path on Windows

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "opencode-antigravity-quota",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,18 +1,13 @@
 import * as path from "path";
 import * as os from "os";
 
-const isWindows = os.platform() === "win32";
-
 const opencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
 
-// Define base configuration directory based on OS
-// Windows: %APPDATA%/opencode (e.g., C:\Users\User\AppData\Roaming\opencode)
-// Mac/Linux: ~/.config/opencode
+// Define base configuration directory
+// Windows/Mac/Linux: ~/.config/opencode
 const configBase = opencodeConfigDir
   ? opencodeConfigDir
-  : isWindows
-    ? path.join(os.homedir(), "AppData", "Roaming", "opencode")
-    : path.join(os.homedir(), ".config", "opencode");
+  : path.join(os.homedir(), ".config", "opencode");
 
 // OpenCode seems to always use .config/opencode for commands, even on Windows
 const commandBase = opencodeConfigDir
@@ -69,9 +64,7 @@ export const CONFIG_PATH = path.join(configBase, "antigravity-accounts.json");
 const xdgData = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
 const dataBase = opencodeConfigDir
   ? opencodeConfigDir
-  : isWindows
-    ? configBase
-    : path.join(xdgData, "opencode");
+  : path.join(xdgData, "opencode");
 
 export const CONFIG_PATHS = Array.from(new Set([
   CONFIG_PATH,

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -21,10 +21,7 @@ describe("Constants", () => {
     // Use a cache-busting query to force re-evaluation of the module
     const constants = await import(`../src/constants.ts?update=${Date.now()}`);
     
-    const isWindows = os.platform() === "win32";
-    const expectedConfigBase = isWindows
-      ? path.join(os.homedir(), "AppData", "Roaming", "opencode")
-      : path.join(os.homedir(), ".config", "opencode");
+    const expectedConfigBase = path.join(os.homedir(), ".config", "opencode");
     
     expect(constants.CONFIG_PATH).toBe(path.join(expectedConfigBase, "antigravity-accounts.json"));
     


### PR DESCRIPTION
Fixes #15, tested locally.

Environment:
* OS: Windows 11
* OpenCode: 1.17.18

Note, using `opencode-antigravity-auth-updated@latest` instead of `opencode-antigravity-auth@1.2.8`. This shouldn't cause any issue.